### PR TITLE
fix(transfer): resolve directory transfer hang at 0 bits

### DIFF
--- a/crates/yoop-core/src/preview/mod.rs
+++ b/crates/yoop-core/src/preview/mod.rs
@@ -176,10 +176,7 @@ impl PreviewGenerator {
 
         let metadata = std::fs::metadata(path)?;
 
-        // Try to open the image
         let Ok(img) = image::open(path) else {
-            // If image cannot be opened (e.g., unsupported format like JPEG),
-            // return a preview with just metadata
             return Ok(Preview {
                 preview_type: PreviewType::Icon,
                 data: String::new(),
@@ -194,17 +191,14 @@ impl PreviewGenerator {
         let (width, height) = img.dimensions();
         let (max_w, max_h) = self.config.thumbnail_size;
 
-        // Generate thumbnail
         let thumb = img.thumbnail(max_w, max_h);
 
-        // Encode as PNG to a buffer
         let mut buf = Vec::new();
         let mut cursor = Cursor::new(&mut buf);
         thumb
             .write_to(&mut cursor, image::ImageFormat::Png)
             .map_err(|e| crate::error::Error::Io(std::io::Error::other(e.to_string())))?;
 
-        // Base64 encode the thumbnail
         let encoded = base64::engine::general_purpose::STANDARD.encode(&buf);
 
         Ok(Preview {
@@ -247,7 +241,6 @@ impl PreviewGenerator {
 
         #[cfg(not(feature = "web"))]
         {
-            // Without the web feature, zip crate is not available
             let metadata = std::fs::metadata(path)?;
             Ok(Preview {
                 preview_type: PreviewType::ArchiveListing,
@@ -269,9 +262,7 @@ impl PreviewGenerator {
         let metadata = std::fs::metadata(path)?;
         let file = File::open(path)?;
 
-        // Try to open as ZIP archive
         let Ok(archive) = zip::ZipArchive::new(file) else {
-            // Not a valid ZIP file, return empty listing
             return Ok(Preview {
                 preview_type: PreviewType::ArchiveListing,
                 data: "[]".to_string(),
@@ -286,7 +277,6 @@ impl PreviewGenerator {
 
         let total_files = archive.len();
 
-        // Collect file names (up to 50 entries)
         let entries: Vec<String> = archive.file_names().take(50).map(String::from).collect();
 
         let data = serde_json::to_string(&entries)
@@ -338,7 +328,6 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let file_path = temp_dir.path().join("large.txt");
 
-        // Create a file larger than max_text_length
         let content = "x".repeat(2000);
         std::fs::write(&file_path, &content).unwrap();
 
@@ -359,7 +348,6 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let file_path = temp_dir.path().join("test.png");
 
-        // Create a simple 2x2 PNG image
         let img = image::RgbImage::from_fn(100, 100, |x, y| {
             if (x + y) % 2 == 0 {
                 image::Rgb([255, 0, 0])
@@ -379,7 +367,6 @@ mod tests {
             "Thumbnail data should not be empty"
         );
 
-        // Verify dimensions metadata
         let meta = preview.metadata.unwrap();
         assert_eq!(meta.dimensions, Some((100, 100)));
     }
@@ -388,7 +375,6 @@ mod tests {
     async fn test_preview_type_detection() {
         let generator = PreviewGenerator::new();
 
-        // Test image detection
         assert_eq!(
             generator.determine_preview_type(Path::new("image.png"), None),
             PreviewType::Thumbnail
@@ -398,7 +384,6 @@ mod tests {
             PreviewType::Thumbnail
         );
 
-        // Test text detection
         assert_eq!(
             generator.determine_preview_type(Path::new("file.txt"), None),
             PreviewType::Text
@@ -412,7 +397,6 @@ mod tests {
             PreviewType::Text
         );
 
-        // Test archive detection
         assert_eq!(
             generator.determine_preview_type(Path::new("archive.zip"), None),
             PreviewType::ArchiveListing
@@ -422,7 +406,6 @@ mod tests {
             PreviewType::ArchiveListing
         );
 
-        // Test icon fallback
         assert_eq!(
             generator.determine_preview_type(Path::new("unknown.xyz"), None),
             PreviewType::Icon
@@ -451,7 +434,6 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let zip_path = temp_dir.path().join("test.zip");
 
-        // Create a simple ZIP file with some entries
         let file = std::fs::File::create(&zip_path).unwrap();
         let mut zip = zip::ZipWriter::new(file);
 

--- a/npm/yoop/bin.js
+++ b/npm/yoop/bin.js
@@ -4,92 +4,92 @@ const { spawn } = require("child_process");
 const path = require("path");
 const fs = require("fs");
 
-/**
- * Platform to npm package name mapping
- */
 const PLATFORMS = {
-  "linux-x64": {
-    packages: ["@sanchxt/yoop-linux-x64-musl", "@sanchxt/yoop-linux-x64-gnu"],
-  },
-  "linux-arm64": {
-    packages: ["@sanchxt/yoop-linux-arm64-gnu"],
-  },
-  "darwin-x64": {
-    packages: ["@sanchxt/yoop-darwin-x64"],
-  },
-  "darwin-arm64": {
-    packages: ["@sanchxt/yoop-darwin-arm64"],
-  },
-  "win32-x64": {
-    packages: ["@sanchxt/yoop-win32-x64-msvc"],
-  },
+    "linux-x64": {
+        packages: [
+            "@sanchxt/yoop-linux-x64-musl",
+            "@sanchxt/yoop-linux-x64-gnu",
+        ],
+    },
+    "linux-arm64": {
+        packages: ["@sanchxt/yoop-linux-arm64-gnu"],
+    },
+    "darwin-x64": {
+        packages: ["@sanchxt/yoop-darwin-x64"],
+    },
+    "darwin-arm64": {
+        packages: ["@sanchxt/yoop-darwin-arm64"],
+    },
+    "win32-x64": {
+        packages: ["@sanchxt/yoop-win32-x64-msvc"],
+    },
 };
 
-/**
- * Find the binary path for the current platform
- */
 function getBinaryPath() {
-  const platform = process.platform;
-  const arch = process.arch;
-  const key = `${platform}-${arch}`;
+    const platform = process.platform;
+    const arch = process.arch;
+    const key = `${platform}-${arch}`;
 
-  const platformConfig = PLATFORMS[key];
-  if (!platformConfig) {
-    console.error(`Error: Unsupported platform: ${platform}-${arch}`);
-    console.error("Supported platforms: linux-x64, linux-arm64, darwin-x64, darwin-arm64, win32-x64");
-    process.exit(1);
-  }
-
-  const binName = platform === "win32" ? "yoop.exe" : "yoop";
-
-  // Try each package in order (musl first for Linux, as it's more portable)
-  for (const packageName of platformConfig.packages) {
-    try {
-      const packagePath = require.resolve(`${packageName}/package.json`);
-      const binPath = path.join(path.dirname(packagePath), "bin", binName);
-
-      if (fs.existsSync(binPath)) {
-        return binPath;
-      }
-    } catch {
-      // Package not installed, try next
-      continue;
+    const platformConfig = PLATFORMS[key];
+    if (!platformConfig) {
+        console.error(`Error: Unsupported platform: ${platform}-${arch}`);
+        console.error(
+            "Supported platforms: linux-x64, linux-arm64, darwin-x64, darwin-arm64, win32-x64"
+        );
+        process.exit(1);
     }
-  }
 
-  console.error(`Error: Could not find yoop binary for ${platform}-${arch}`);
-  console.error("");
-  console.error("This usually means the platform-specific package failed to install.");
-  console.error("Try reinstalling:");
-  console.error("  npm install -g yoop");
-  console.error("");
-  console.error("If the problem persists, please file an issue at:");
-  console.error("  https://github.com/sanchxt/yoop/issues");
-  process.exit(1);
+    const binName = platform === "win32" ? "yoop.exe" : "yoop";
+
+    for (const packageName of platformConfig.packages) {
+        try {
+            const packagePath = require.resolve(`${packageName}/package.json`);
+            const binPath = path.join(
+                path.dirname(packagePath),
+                "bin",
+                binName
+            );
+
+            if (fs.existsSync(binPath)) {
+                return binPath;
+            }
+        } catch {
+            continue;
+        }
+    }
+
+    console.error(`Error: Could not find yoop binary for ${platform}-${arch}`);
+    console.error("");
+    console.error(
+        "This usually means the platform-specific package failed to install."
+    );
+    console.error("Try reinstalling:");
+    console.error("  npm install -g yoop");
+    console.error("");
+    console.error("If the problem persists, please file an issue at:");
+    console.error("  https://github.com/sanchxt/yoop/issues");
+    process.exit(1);
 }
 
-/**
- * Run the binary with the given arguments
- */
 function run() {
-  const binPath = getBinaryPath();
+    const binPath = getBinaryPath();
 
-  const child = spawn(binPath, process.argv.slice(2), {
-    stdio: "inherit",
-    shell: false,
-  });
+    const child = spawn(binPath, process.argv.slice(2), {
+        stdio: "inherit",
+        shell: false,
+    });
 
-  child.on("error", (err) => {
-    console.error(`Error: Failed to execute yoop: ${err.message}`);
-    process.exit(1);
-  });
+    child.on("error", (err) => {
+        console.error(`Error: Failed to execute yoop: ${err.message}`);
+        process.exit(1);
+    });
 
-  child.on("exit", (code, signal) => {
-    if (signal) {
-      process.exit(1);
-    }
-    process.exit(code ?? 0);
-  });
+    child.on("exit", (code, signal) => {
+        if (signal) {
+            process.exit(1);
+        }
+        process.exit(code ?? 0);
+    });
 }
 
 run();


### PR DESCRIPTION
Fixes directory transfers that get stuck at 0 bits transferred.

Changes:
- Added ChunkAck acknowledgment for directories and empty files
- Fixed empty files being incorrectly created as directories
- Ensured protocol symmetry between sender and receiver

Tested with `cargo test -p yoop-core` - all tests pass.