### PR TITLE
feat(qr): add QR code support for share codes

### DIFF
--- a/crates/yoop-cli/src/commands/share.rs
+++ b/crates/yoop-cli/src/commands/share.rs
@@ -49,7 +49,7 @@ pub async fn run(args: ShareArgs) -> Result<()> {
     let total_size: u64 = files.iter().map(|f| f.size).sum();
     let code = session.code().to_string();
 
-    display_share_info(&files, total_size, &code, &args)?;
+    display_share_info(&files, total_size, &code, &args, &global_config)?;
 
     let progress_rx = session.progress();
     let expire_duration =
@@ -99,6 +99,7 @@ fn display_share_info(
     total_size: u64,
     code: &str,
     args: &ShareArgs,
+    global_config: &yoop_core::config::Config,
 ) -> Result<()> {
     let total_files = files.len();
 
@@ -128,7 +129,10 @@ fn display_share_info(
         });
         println!("{}", serde_json::to_string_pretty(&output)?);
     } else if !args.quiet {
-        CodeBox::new(code).with_expire(&args.expire).display();
+        CodeBox::new(code)
+            .with_expire(&args.expire)
+            .with_qr(global_config.ui.show_qr)
+            .display();
         println!();
     }
 

--- a/crates/yoop-cli/src/ui.rs
+++ b/crates/yoop-cli/src/ui.rs
@@ -8,19 +8,31 @@ const BOX_WIDTH: usize = 33;
 pub struct CodeBox<'a> {
     code: &'a str,
     expire: Option<&'a str>,
+    show_qr: bool,
 }
 
 impl<'a> CodeBox<'a> {
     /// Create a new code box.
     #[must_use]
     pub const fn new(code: &'a str) -> Self {
-        Self { code, expire: None }
+        Self {
+            code,
+            expire: None,
+            show_qr: false,
+        }
     }
 
     /// Add expiration time to the box.
     #[must_use]
     pub const fn with_expire(mut self, expire: &'a str) -> Self {
         self.expire = Some(expire);
+        self
+    }
+
+    /// Enable QR code display.
+    #[must_use]
+    pub const fn with_qr(mut self, show: bool) -> Self {
+        self.show_qr = show;
         self
     }
 
@@ -41,6 +53,17 @@ impl<'a> CodeBox<'a> {
         }
 
         println!("  └{}┘", "─".repeat(BOX_WIDTH));
+
+        if self.show_qr {
+            if let Ok(qr) = yoop_core::qr::generate_ascii(self.code) {
+                println!();
+                for line in qr.lines() {
+                    println!("  {}", line);
+                }
+                println!();
+                println!("  Scan to receive: yoop://{}", self.code);
+            }
+        }
     }
 }
 

--- a/crates/yoop-core/src/config/mod.rs
+++ b/crates/yoop-core/src/config/mod.rs
@@ -310,7 +310,7 @@ impl Default for UiConfig {
     fn default() -> Self {
         Self {
             theme: "auto".to_string(),
-            show_qr: true,
+            show_qr: false,
             notifications: true,
             sound: true,
         }

--- a/crates/yoop-core/src/lib.rs
+++ b/crates/yoop-core/src/lib.rs
@@ -21,6 +21,7 @@
 //! - [`history`] - Transfer history tracking and persistence
 //! - [`preview`] - File preview generation (thumbnails, text snippets)
 //! - [`protocol`] - LDRP wire protocol implementation
+//! - [`qr`] - QR code generation for share codes
 //! - [`transfer`] - File transfer engine
 //! - [`trust`] - Trusted devices management
 //! - [`web`] - Embedded web server for browser-based access
@@ -63,6 +64,7 @@ pub mod file;
 pub mod history;
 pub mod preview;
 pub mod protocol;
+pub mod qr;
 pub mod transfer;
 pub mod trust;
 

--- a/crates/yoop-core/src/qr/mod.rs
+++ b/crates/yoop-core/src/qr/mod.rs
@@ -1,0 +1,285 @@
+//! QR code generation for Yoop share codes.
+//!
+//! This module generates QR codes containing deep links for mobile scanning.
+//!
+//! ## Features
+//!
+//! - ASCII art QR for terminal display
+//! - SVG QR for web interface
+//! - Configurable URL scheme for deep links
+//!
+//! ## Example
+//!
+//! ```rust,ignore
+//! use yoop_core::qr;
+//!
+//! let ascii = qr::generate_ascii("A7K9")?;
+//! println!("{}", ascii);
+//!
+//! let svg = qr::generate_svg("A7K9")?;
+//! ```
+
+use base64::Engine;
+use qrcode::render::{svg, unicode};
+use qrcode::{EcLevel, QrCode};
+
+use crate::error::{Error, Result};
+
+/// Configuration for QR code generation.
+#[derive(Debug, Clone)]
+pub struct QrConfig {
+    /// URL scheme for deep links (default: "yoop")
+    pub scheme: String,
+    /// Error correction level (default: Medium)
+    pub error_correction: EcLevel,
+}
+
+impl Default for QrConfig {
+    fn default() -> Self {
+        Self {
+            scheme: "yoop".to_string(),
+            error_correction: EcLevel::M,
+        }
+    }
+}
+
+/// Create a deep link URL from a share code.
+///
+/// # Arguments
+///
+/// * `code` - The share code (e.g., "A7K9")
+/// * `config` - QR configuration
+///
+/// # Returns
+///
+/// A deep link URL (e.g., "yoop://A7K9")
+///
+/// # Example
+///
+/// ```
+/// use yoop_core::qr::{create_deep_link, QrConfig};
+///
+/// let link = create_deep_link("A7K9", &QrConfig::default());
+/// assert_eq!(link, "yoop://A7K9");
+/// ```
+#[must_use]
+pub fn create_deep_link(code: &str, config: &QrConfig) -> String {
+    format!("{}://{}", config.scheme, code.to_uppercase())
+}
+
+/// Generate ASCII art QR code for terminal display.
+///
+/// Uses Unicode block characters for compact display in terminals.
+///
+/// # Arguments
+///
+/// * `code` - The share code (e.g., "A7K9")
+///
+/// # Errors
+///
+/// Returns an error if QR code generation fails.
+///
+/// # Example
+///
+/// ```
+/// use yoop_core::qr::generate_ascii;
+///
+/// let qr = generate_ascii("A7K9").unwrap();
+/// println!("{}", qr);
+/// ```
+pub fn generate_ascii(code: &str) -> Result<String> {
+    let deep_link = create_deep_link(code, &QrConfig::default());
+
+    let qr_code = QrCode::with_error_correction_level(&deep_link, EcLevel::M)
+        .map_err(|e| Error::Internal(format!("Failed to generate QR code: {e}")))?;
+
+    let rendered = qr_code
+        .render::<unicode::Dense1x2>()
+        .dark_color(unicode::Dense1x2::Light)
+        .light_color(unicode::Dense1x2::Dark)
+        .build();
+
+    Ok(rendered)
+}
+
+/// Generate SVG QR code for web interface.
+///
+/// Returns an SVG string that can be embedded in HTML.
+///
+/// # Arguments
+///
+/// * `code` - The share code (e.g., "A7K9")
+///
+/// # Errors
+///
+/// Returns an error if QR code generation fails.
+///
+/// # Example
+///
+/// ```
+/// use yoop_core::qr::generate_svg;
+///
+/// let svg = generate_svg("A7K9").unwrap();
+/// assert!(svg.contains("<svg"));
+/// assert!(svg.contains("</svg>"));
+/// ```
+pub fn generate_svg(code: &str) -> Result<String> {
+    let deep_link = create_deep_link(code, &QrConfig::default());
+
+    let qr_code = QrCode::with_error_correction_level(&deep_link, EcLevel::M)
+        .map_err(|e| Error::Internal(format!("Failed to generate QR code: {e}")))?;
+
+    let svg_string = qr_code
+        .render::<svg::Color>()
+        .min_dimensions(200, 200)
+        .dark_color(svg::Color("#000000"))
+        .light_color(svg::Color("#ffffff"))
+        .build();
+
+    Ok(svg_string)
+}
+
+/// Generate base64-encoded PNG QR code.
+///
+/// Useful for embedding in web pages as data URLs.
+///
+/// # Arguments
+///
+/// * `code` - The share code (e.g., "A7K9")
+/// * `size` - Size of the QR code in pixels
+///
+/// # Errors
+///
+/// Returns an error if QR code generation or encoding fails.
+///
+/// # Example
+///
+/// ```
+/// use yoop_core::qr::generate_png_base64;
+///
+/// let png_data = generate_png_base64("A7K9", 256).unwrap();
+/// assert!(!png_data.is_empty());
+/// ```
+pub fn generate_png_base64(code: &str, size: u32) -> Result<String> {
+    use image::Luma;
+
+    let deep_link = create_deep_link(code, &QrConfig::default());
+
+    let qr_code = QrCode::with_error_correction_level(&deep_link, EcLevel::M)
+        .map_err(|e| Error::Internal(format!("Failed to generate QR code: {e}")))?;
+
+    let image = qr_code.render::<Luma<u8>>().build();
+
+    let scaled = image::imageops::resize(&image, size, size, image::imageops::FilterType::Nearest);
+
+    let mut png_bytes = Vec::new();
+    {
+        use image::ImageEncoder;
+        let encoder = image::codecs::png::PngEncoder::new(&mut png_bytes);
+        encoder
+            .write_image(&scaled, size, size, image::ExtendedColorType::L8)
+            .map_err(|e| Error::Internal(format!("Failed to encode PNG: {e}")))?;
+    }
+
+    Ok(base64::prelude::BASE64_STANDARD.encode(&png_bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_deep_link_default() {
+        let link = create_deep_link("A7K9", &QrConfig::default());
+        assert_eq!(link, "yoop://A7K9");
+    }
+
+    #[test]
+    fn test_create_deep_link_uppercase() {
+        let link = create_deep_link("a7k9", &QrConfig::default());
+        assert_eq!(link, "yoop://A7K9");
+    }
+
+    #[test]
+    fn test_create_deep_link_custom_scheme() {
+        let config = QrConfig {
+            scheme: "localdrop".to_string(),
+            ..Default::default()
+        };
+        let link = create_deep_link("A7K9", &config);
+        assert_eq!(link, "localdrop://A7K9");
+    }
+
+    #[test]
+    fn test_generate_ascii_not_empty() {
+        let qr = generate_ascii("A7K9").unwrap();
+        assert!(!qr.is_empty());
+        assert!(qr.contains('█') || qr.contains('▀') || qr.contains('▄'));
+    }
+
+    #[test]
+    fn test_generate_ascii_multiline() {
+        let qr = generate_ascii("A7K9").unwrap();
+        assert!(qr.lines().count() > 5);
+    }
+
+    #[test]
+    fn test_generate_svg_valid_xml() {
+        let svg = generate_svg("A7K9").unwrap();
+        assert!(
+            svg.starts_with("<?xml") || svg.starts_with("<svg"),
+            "SVG should start with XML declaration or svg tag"
+        );
+        assert!(svg.contains("</svg>"), "SVG should have closing tag");
+        assert!(
+            svg.contains("xmlns") || svg.contains("viewBox"),
+            "SVG should have xmlns or viewBox attribute"
+        );
+    }
+
+    #[test]
+    fn test_generate_svg_has_dimensions() {
+        let svg = generate_svg("A7K9").unwrap();
+        assert!(svg.contains("width") && svg.contains("height"));
+    }
+
+    #[test]
+    fn test_qr_code_generation_succeeds() {
+        let result = QrCode::new("yoop://A7K9");
+        assert!(result.is_ok());
+
+        let qr = result.unwrap();
+        assert!(matches!(qr.version(), qrcode::Version::Normal(_)));
+    }
+
+    #[test]
+    fn test_generate_png_base64_not_empty() {
+        let png = generate_png_base64("A7K9", 256).unwrap();
+        assert!(!png.is_empty());
+
+        let decoded = base64::prelude::BASE64_STANDARD.decode(&png).unwrap();
+        assert!(decoded.len() > 100);
+    }
+
+    #[test]
+    fn test_different_codes_produce_different_qrs() {
+        let qr1 = generate_ascii("A7K9").unwrap();
+        let qr2 = generate_ascii("B8M3").unwrap();
+        assert_ne!(qr1, qr2);
+    }
+
+    #[test]
+    fn test_config_error_correction_levels() {
+        let config_low = QrConfig {
+            scheme: "yoop".to_string(),
+            error_correction: EcLevel::L,
+        };
+        let config_high = QrConfig {
+            scheme: "yoop".to_string(),
+            error_correction: EcLevel::H,
+        };
+
+        assert_eq!(config_low.error_correction, EcLevel::L);
+        assert_eq!(config_high.error_correction, EcLevel::H);
+    }
+}

--- a/crates/yoop-core/src/web/assets/app.js
+++ b/crates/yoop-core/src/web/assets/app.js
@@ -24,6 +24,8 @@ const elements = {
     shareCodeDisplay: document.getElementById("share-code-display"),
     shareCode: document.getElementById("share-code"),
     expireTime: document.getElementById("expire-time"),
+    qrCodeContainer: document.getElementById("qr-code-container"),
+    qrCode: document.getElementById("qr-code"),
     shareStatus: document.getElementById("share-status"),
     btnCancelShare: document.getElementById("btn-cancel-share"),
 
@@ -221,6 +223,8 @@ function resetShareUI() {
     elements.dropZone.hidden = false;
     elements.selectedFiles.hidden = state.selectedFiles.length === 0;
     elements.shareCodeDisplay.hidden = true;
+    elements.qrCodeContainer.hidden = true;
+    elements.qrCode.innerHTML = "";
 }
 
 function resetReceiveUI() {
@@ -326,6 +330,13 @@ async function startShare() {
         elements.selectedFiles.hidden = true;
         elements.shareCodeDisplay.hidden = false;
 
+        if (result.qr_svg) {
+            elements.qrCode.innerHTML = result.qr_svg;
+            elements.qrCodeContainer.hidden = false;
+        } else {
+            elements.qrCodeContainer.hidden = true;
+        }
+
         updateExpireTime();
         state.expireInterval = setInterval(updateExpireTime, 1000);
 
@@ -371,12 +382,25 @@ async function connectToCode() {
 
             let previewHtml = "";
             if (file.preview) {
-                if (file.preview.preview_type === "thumbnail" && file.preview.data) {
+                if (
+                    file.preview.preview_type === "thumbnail" &&
+                    file.preview.data
+                ) {
                     previewHtml = `<img class="file-preview-img" src="data:${file.preview.mime_type};base64,${file.preview.data}" alt="Preview">`;
-                } else if (file.preview.preview_type === "text" && file.preview.data) {
-                    const snippet = file.preview.data.substring(0, 60).replace(/\n/g, " ");
-                    previewHtml = `<span class="file-preview-text">"${snippet}${file.preview.data.length > 60 ? "..." : ""}"</span>`;
-                } else if (file.preview.preview_type === "archive" && file.preview.file_count) {
+                } else if (
+                    file.preview.preview_type === "text" &&
+                    file.preview.data
+                ) {
+                    const snippet = file.preview.data
+                        .substring(0, 60)
+                        .replace(/\n/g, " ");
+                    previewHtml = `<span class="file-preview-text">"${snippet}${
+                        file.preview.data.length > 60 ? "..." : ""
+                    }"</span>`;
+                } else if (
+                    file.preview.preview_type === "archive" &&
+                    file.preview.file_count
+                ) {
                     previewHtml = `<span class="file-preview-meta">(${file.preview.file_count} files)</span>`;
                 }
             }

--- a/crates/yoop-core/src/web/assets/index.html
+++ b/crates/yoop-core/src/web/assets/index.html
@@ -44,6 +44,12 @@
                         <p id="share-expires">
                             Expires in <span id="expire-time"></span>
                         </p>
+
+                        <div id="qr-code-container" class="qr-container" hidden>
+                            <div id="qr-code"></div>
+                            <p class="qr-hint">Scan with phone to receive</p>
+                        </div>
+
                         <p id="share-status">Waiting for receiver...</p>
                         <button id="btn-cancel-share" class="secondary">
                             Cancel

--- a/crates/yoop-core/src/web/assets/style.css
+++ b/crates/yoop-core/src/web/assets/style.css
@@ -254,6 +254,31 @@ main {
     color: var(--text-muted);
 }
 
+.qr-container {
+    text-align: center;
+    margin: 1.5rem 0;
+}
+
+#qr-code {
+    display: inline-block;
+    padding: 1rem;
+    background: white;
+    border-radius: 8px;
+    box-shadow: var(--shadow);
+}
+
+#qr-code svg {
+    display: block;
+    width: 150px;
+    height: 150px;
+}
+
+.qr-hint {
+    color: var(--text-muted);
+    font-size: 0.75rem;
+    margin-top: 0.5rem;
+}
+
 #code-input-section {
     text-align: center;
 }
@@ -435,6 +460,11 @@ footer {
 
     #code-input {
         font-size: 1.25rem;
+    }
+
+    #qr-code svg {
+        width: 120px;
+        height: 120px;
     }
 }
 

--- a/crates/yoop-core/src/web/mod.rs
+++ b/crates/yoop-core/src/web/mod.rs
@@ -21,6 +21,7 @@
 //! | GET | /api/network | Network info |
 //! | POST | /api/share | Start sharing (multipart upload) |
 //! | GET | /api/share/code | Get current share code |
+//! | GET | /api/share/qr | Get QR code SVG |
 //! | DELETE | /api/share | Cancel share |
 //! | POST | /api/receive | Connect to share code |
 //! | POST | /api/receive/accept | Accept transfer |
@@ -109,6 +110,7 @@ fn create_router(state: SharedState) -> Router {
         .route("/share", post(handlers::create_share))
         .route("/share", delete(handlers::cancel_share))
         .route("/share/code", get(handlers::get_share_code))
+        .route("/share/qr", get(handlers::get_share_qr))
         .route("/receive", post(handlers::start_receive))
         .route("/receive/accept", post(handlers::accept_receive))
         .route("/receive/decline", post(handlers::decline_receive))


### PR DESCRIPTION
## Summary

Adds QR code generation and display for share codes across CLI and web interface.

**Features:**
- QR codes encoding `yoop://CODE` deep links
- ASCII QR display in CLI terminal
- SVG QR rendering in web interface
- Config toggle `ui.show_qr` (default: false)
- `/api/share/qr` endpoint for direct SVG access

**Status:** Experimental feature disabled by default. Requires future mobile app to handle deep links.

**Changes:**
- New `qr` module with ASCII, SVG, PNG generation (11 unit tests)
- CLI integration via `CodeBox`
- Web integration via `ShareResponse`
- Documentation updates in README

**Testing:**
- All 151 existing tests pass
- 11 new QR-specific unit tests added
- Zero clippy warnings