### PR TITLE
fix(update): detect package manager from installed yoop location

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3807,7 +3807,7 @@ dependencies = [
 
 [[package]]
 name = "yoop"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "arboard",
@@ -3828,7 +3828,7 @@ dependencies = [
 
 [[package]]
 name = "yoop-core"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "arboard",
  "async-stream",

--- a/crates/yoop-cli/src/commands/update.rs
+++ b/crates/yoop-cli/src/commands/update.rs
@@ -55,8 +55,7 @@ pub async fn run(args: UpdateArgs) -> Result<()> {
         println!();
     }
 
-    if args.package_manager.is_some() {
-        let pm_str = args.package_manager.as_ref().unwrap();
+    if let Some(pm_str) = &args.package_manager {
         let pm_kind = match pm_str.to_lowercase().as_str() {
             "npm" => yoop_core::config::PackageManagerKind::Npm,
             "pnpm" => yoop_core::config::PackageManagerKind::Pnpm,


### PR DESCRIPTION
## Summary
- Adds detection tier that checks which package manager has yoop installed globally
- Fixes `yoop update` using wrong package manager (e.g., pnpm when installed via npm)