### PR TITLE
multiarch releases witth cross (amd64 & aarch64) + GHA for builds for…

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,6 @@
+[build]
+target = "aarch64-unknown-linux-gnu"
+
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"
+ar = "aarch64-linux-gnu-ar"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,0 @@
-[build]
-target = "aarch64-unknown-linux-gnu"
-
-[target.aarch64-unknown-linux-gnu]
-linker = "aarch64-linux-gnu-gcc"
-ar = "aarch64-linux-gnu-ar"

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -3,7 +3,7 @@ name: Release Binaries
 on:
   push:
     tags:
-      - "*"
+      - "v*"
   workflow_dispatch:
     inputs:
       tag:
@@ -49,6 +49,10 @@ jobs:
 
       - name: Build aarch64 release for arm
         run: cargo build --release --target aarch64-unknown-linux-gnu
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+          CC_aarch64_unknown_linux_gnu: aarch64-linux-gnu-gcc
+          AR_aarch64_unknown_linux_gnu: aarch64-linux-gnu-ar
 
       - name: Rename binaries
         run: |

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,49 @@
+name: Release Binaries
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release-binaries:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo with release tag
+        uses: actions/checkout@v5
+
+      - name: Install system deps for aarch64 cross-build
+        run: |
+          sudo apt update
+          sudo apt install -y \
+            gcc-aarch64-linux-gnu \
+            gcc-x86-64-linux-gnu \
+            binutils-aarch64-linux-gnu \
+            libc6-dev-arm64-cross
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-unknown-linux-gnu
+
+      - name: Build x86_64 release
+        run: cargo build --release --target x86_64-unknown-linux-gnu
+
+      - name: Build aarch64 release for arm
+        run: cargo build --release --target aarch64-unknown-linux-gnu
+
+       - name: Rename binaries
+        run: |
+          cp target/x86_64-unknown-linux-gnu/release/yoop yoop-amd64
+          cp target/aarch64-unknown-linux-gnu/release/yoop yoop-aarch64
+
+      - name: Push binaries to github release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            yoop-amd64
+            yoop-aarch64

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -2,9 +2,14 @@ name: Release Binaries
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - "*"
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (default: build-release)"
+        required: true
+        default: build-release
 
 permissions:
   contents: write
@@ -15,6 +20,15 @@ jobs:
     steps:
       - name: Checkout repo with release tag
         uses: actions/checkout@v5
+
+      - name: Resolve tag
+        id: tag
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          else
+            echo "tag=${{ inputs.tag }}" >> $GITHUB_OUTPUT
+          fi
 
       - name: Install system deps for aarch64 cross-build
         run: |
@@ -36,7 +50,7 @@ jobs:
       - name: Build aarch64 release for arm
         run: cargo build --release --target aarch64-unknown-linux-gnu
 
-       - name: Rename binaries
+      - name: Rename binaries
         run: |
           cp target/x86_64-unknown-linux-gnu/release/yoop yoop-amd64
           cp target/aarch64-unknown-linux-gnu/release/yoop yoop-aarch64
@@ -44,6 +58,7 @@ jobs:
       - name: Push binaries to github release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ steps.tag.outputs.tag }}
           files: |
             yoop-amd64
             yoop-aarch64

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -42,9 +42,27 @@ jobs:
         with:
           node-version: 20
 
+      - name: Install Rust
+        if: ${{ steps.release.outputs.release_created }}
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Sync npm package versions
         if: ${{ steps.release.outputs.pr }}
         run: node scripts/sync-versions.js
+
+      - name: Build release binary
+        if: ${{ steps.release.outputs.release_created }}
+        run: cargo build --workspace --release
+
+      - name: Binary to GitHub Release for Linux-x86_64
+        if: ${{ steps.release.outputs.release_created }}
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.release.outputs.tag_name }}
+          name: yoop_linux-x86_64
+          files: target/release/yoop
+          draft: false
+          prerelease: false
 
       - name: Commit synced versions
         if: ${{ steps.release.outputs.pr }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,7 +19,6 @@ jobs:
       tag_name: ${{ steps.release.outputs.tag_name }}
       version: ${{ steps.release.outputs.version }}
       pr: ${{ steps.release.outputs.pr }}
-
     steps:
       - name: Run release-please
         uses: googleapis/release-please-action@v4
@@ -42,27 +41,9 @@ jobs:
         with:
           node-version: 20
 
-      - name: Install Rust
-        if: ${{ steps.release.outputs.release_created }}
-        uses: dtolnay/rust-toolchain@stable
-
       - name: Sync npm package versions
         if: ${{ steps.release.outputs.pr }}
         run: node scripts/sync-versions.js
-
-      - name: Build release binary
-        if: ${{ steps.release.outputs.release_created }}
-        run: cargo build --workspace --release
-
-      - name: Binary to GitHub Release for Linux-x86_64
-        if: ${{ steps.release.outputs.release_created }}
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.release.outputs.tag_name }}
-          name: yoop_linux-x86_64
-          files: target/release/yoop
-          draft: false
-          prerelease: false
 
       - name: Commit synced versions
         if: ${{ steps.release.outputs.pr }}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build release test lint fmt check clean doc install help \
+.PHONY: all build release release-multi test lint fmt check clean doc install help \
        npm-build npm-build-native npm-publish npm-dry-run sync-versions
 
 # Default target
@@ -8,9 +8,15 @@ all: check
 build:
 	cargo build --workspace
 
-# Build release
+# Build release for host architecture at target/release
 release:
 	cargo build --workspace --release
+
+# Build release for host architecture at target/<architecture>/release
+release-multi:
+	cargo install cross
+	cross build --release  --target x86_64-unknown-linux-gnu
+	cross build --release  --target aarch64-unknown-linux-gnu
 
 # Run all tests
 test:
@@ -75,7 +81,8 @@ help:
 	@echo "Targets:"
 	@echo "  all            Run all checks (default)"
 	@echo "  build          Build debug version"
-	@echo "  release        Build release version"
+	@echo "  release        Build release for host architecture at target/release"
+	@echo "  release-multi  Build release for multiple CPU architectures at each: target/<architecture>/release"
 	@echo "  test           Run all tests"
 	@echo "  test-verbose   Run tests with output"
 	@echo "  lint           Run clippy linter"

--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,11 @@ release:
 # Build release for host architecture at target/<architecture>/release
 release-multi:
 	cargo install cross
-	@if [ ! -d ./target/x86_64-unknown-linux-gnu/release ]; then \
+	@if [ ! -f ./target/x86_64-unknown-linux-gnu/release/yoop ]; then \
 		cross build --release  --target x86_64-unknown-linux-gnu; \
 	else echo "./target/x86_64-unknown-linux-gnu/release already exists, skipping build..."; \
 	fi
-	@if [ ! -d ./target/aarch64-unknown-linux-gnu/release ]; then \
+	@if [ ! -f ./target/aarch64-unknown-linux-gnu/release/yoop ]; then \
 		cross build --release  --target aarch64-unknown-linux-gnu; \
 	else echo "./target/aarch64-unknown-linux-gnu/release already exists, skipping build..."; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,14 @@ release:
 # Build release for host architecture at target/<architecture>/release
 release-multi:
 	cargo install cross
-	cross build --release  --target x86_64-unknown-linux-gnu
-	cross build --release  --target aarch64-unknown-linux-gnu
+	@if [ ! -d ./target/x86_64-unknown-linux-gnu/release ]; then \
+		cross build --release  --target x86_64-unknown-linux-gnu; \
+	else echo "./target/x86_64-unknown-linux-gnu/release already exists, skipping build..."; \
+	fi
+	@if [ ! -d ./target/aarch64-unknown-linux-gnu/release ]; then \
+		cross build --release  --target aarch64-unknown-linux-gnu; \
+	else echo "./target/aarch64-unknown-linux-gnu/release already exists, skipping build..."; \
+	fi
 
 # Run all tests
 test:


### PR DESCRIPTION
refer #25


[cross](https://github.com/cross-rs/cross) builds for multiarch on linux containers (either docker/portainer) so there's that dependency
and so I didn't add multiarch builds for GHA, only adding the linux_x86_64 build (since ubuntu-latest that the release workflow is using is amd64 based), building for multiarch will either require:
1. cross (that requires docker) and take huge CI time
2. different releases CI jobs for different architectures (which is overkill) 

can use `make release-multi` for multiarch builds locally tho